### PR TITLE
fixed chroot check

### DIFF
--- a/extras_14.04/RAM_Session/redit
+++ b/extras_14.04/RAM_Session/redit
@@ -40,7 +40,8 @@ fi
 # Check if the user is trying to run this script from inside of a chroot #
 ##########################################################################
 
-if [[ "$(ls -di / | cut -d ' ' -f 1)" != 2 ]] && [[ "$(ls -di / | cut -d ' ' -f 1)" != 128 ]]
+ischroot
+if [ $? -eq 0 ]
 then
 	echo "This script cannot be run from inside of a chroot"
 	exit 0

--- a/extras_14.04/RAM_Session/rupdate
+++ b/extras_14.04/RAM_Session/rupdate
@@ -36,7 +36,8 @@ fi
 # Check if the user is trying to run this script from inside of a chroot #
 ##########################################################################
 
-if [[ "$(ls -di / | cut -d ' ' -f 1)" != 2 ]] && [[ "$(ls -di / | cut -d ' ' -f 1)" != 128 ]]
+ischroot
+if [ $? -eq 0 ]
 then
 	echo "This script cannot be run from inside of a chroot"
 	exit 0

--- a/extras_14.04/RAM_Session/rupgrade
+++ b/extras_14.04/RAM_Session/rupgrade
@@ -38,7 +38,9 @@ fi
 # Check if the user is trying to run this script from inside of a chroot #
 ##########################################################################
 
-if [[ "$(ls -di / | cut -d ' ' -f 1)" != 2 ]] && [[ "$(ls -di / | cut -d ' ' -f 1)" != 128 ]]
+
+ischroot
+if [ $? -eq 0 ]
 then
         echo "This script cannot be run from inside of a chroot"
         exit 0

--- a/extras_14.10/RAM_Session/redit
+++ b/extras_14.10/RAM_Session/redit
@@ -40,7 +40,8 @@ fi
 # Check if the user is trying to run this script from inside of a chroot #
 ##########################################################################
 
-if [[ "$(ls -di / | cut -d ' ' -f 1)" != 2 ]] && [[ "$(ls -di / | cut -d ' ' -f 1)" != 128 ]]
+ischroot
+if [ $? -eq 0 ]
 then
 	echo "This script cannot be run from inside of a chroot"
 	exit 0

--- a/extras_14.10/RAM_Session/rupdate
+++ b/extras_14.10/RAM_Session/rupdate
@@ -36,7 +36,8 @@ fi
 # Check if the user is trying to run this script from inside of a chroot #
 ##########################################################################
 
-if [[ "$(ls -di / | cut -d ' ' -f 1)" != 2 ]] && [[ "$(ls -di / | cut -d ' ' -f 1)" != 128 ]]
+ischroot
+if [ $? -eq 0 ]
 then
 	echo "This script cannot be run from inside of a chroot"
 	exit 0

--- a/extras_14.10/RAM_Session/rupgrade
+++ b/extras_14.10/RAM_Session/rupgrade
@@ -38,7 +38,8 @@ fi
 # Check if the user is trying to run this script from inside of a chroot #
 ##########################################################################
 
-if [[ "$(ls -di / | cut -d ' ' -f 1)" != 2 ]] && [[ "$(ls -di / | cut -d ' ' -f 1)" != 128 ]]
+ischroot
+if [ $? -eq 0 ]
 then
         echo "This script cannot be run from inside of a chroot"
         exit 0


### PR DESCRIPTION
Firstly, thank you for your remarkable work.

I use this in `Ubuntu 16.04.3 LTS`(just use `RAM_booster_Ubuntu_14.10_ng.sh`, no any patch), and when i tried to using `redit/rupdate/rupgrade`,they failed because these scripts thought i'm in a chroot jail

So i modifiy them, using `ischroot` which comes from `debianutils`

Here is my test results:


```
$ ls /
bin  boot  cdrom  dev  etc  home  initrd.img  lib  lib64  media  mnt  node_modules  opt  proc  RAM_Session  root  run  sbin  snap  srv  sys  tmp  usr  var  vmlinuz
$ ls -di /
550 /
```